### PR TITLE
Add authorization via api-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ via [GitHub Issues](https://github.com/G4brym/workers-firecrawl/issues).
    Open the URL in your browser to access a Swagger UI for testing the `/search` endpoint directly. Use this URL in your
    Firecrawl SDK configuration.
 
+6. **Authorization (Optional)**
+
+   By default, this worker will accept requests from everyone, so its recommended that you setup authorization,
+   For this, just set the `AUTHORIZATION_KEY` secret in your worker, with the desired api key you want to use.
+
+   ```bash
+   npx wrangler secret put AUTHORIZATION_KEY
+   ```
+
 ### Making Requests
 
 Integrate with the Firecrawl SDK by updating the `apiUrl` to your Worker’s URL:
@@ -77,7 +86,7 @@ Integrate with the Firecrawl SDK by updating the `apiUrl` to your Worker’s URL
 const {FirecrawlApp} = require('@mendable/firecrawl-js');
 
 const firecrawl = new FirecrawlApp({
-    apiKey: 'your-firecrawl-api-key', // Optional, depending on your setup
+    apiKey: 'your-api-key', // Only if AUTHORIZATION_KEY is defined in the worker
     apiUrl: 'https://workers-firecrawl.{your-user}.workers.dev'
 });
 

--- a/src/authorization.ts
+++ b/src/authorization.ts
@@ -1,0 +1,18 @@
+import type { AppContext } from "./index";
+
+export async function authorizationMiddleware(
+	c: AppContext,
+	next: CallableFunction,
+) {
+	if (
+		c.env.AUTHORIZATION_KEY &&
+		c.req.header("authorization") !== `Bearer ${c.env.AUTHORIZATION_KEY}`
+	) {
+		return Response.json(
+			{ success: false, error: "Unauthorized: Invalid token" },
+			{ status: 401 },
+		);
+	}
+
+	await next();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,17 @@
 import { fromHono } from "chanfana";
 import { type Context, Hono } from "hono";
+import { authorizationMiddleware } from "./authorization";
 import { WebSearch } from "./webSearch";
 
 export type Env = {
 	BROWSER: Fetcher;
+	AUTHORIZATION_KEY?: string;
 };
 export type AppContext = Context<{ Bindings: Env }>;
 
 // Start a Hono app
 const app = new Hono();
+app.use("*", authorizationMiddleware);
 
 // Setup OpenAPI registry
 const openapi = fromHono(app, { docs_url: "/" });


### PR DESCRIPTION
 By default, this worker will accept requests from everyone, so its recommended that you setup authorization,
 For this, just set the `AUTHORIZATION_KEY` secret in your worker, with the desired api key you want to use.

 ```bash
 npx wrangler secret put AUTHORIZATION_KEY
 ```

Then, when initializing your firecrawl-sdk, just set the `apiKey` with the same string you entered in the command above
```js
const firecrawl = new FirecrawlApp({
    apiKey: 'your-api-key',
    apiUrl: 'https://workers-firecrawl.{your-user}.workers.dev'
});
```