### PR TITLE
Fix browser resource leak by closing browser after search

### DIFF
--- a/src/webSearch.ts
+++ b/src/webSearch.ts
@@ -109,8 +109,10 @@ async function extractContent(browser: Browser, url: string) {
 			},
 		};
 	} catch (error) {
-		console.error(`Content extraction failed for ${url}: ${(error as Error).message}`)
-		return null
+		console.error(
+			`Content extraction failed for ${url}: ${(error as Error).message}`,
+		);
+		return null;
 	} finally {
 		await page.close();
 	}
@@ -185,22 +187,26 @@ export class WebSearch extends OpenAPIRoute {
 		const data = await this.getValidatedData<typeof this.schema>();
 
 		const browser = await getBrowser(c.env);
-		const searchResults = await performSearch(
-			browser,
-			data.body.query,
-			data.body.limit,
-		);
+		try {
+			const searchResults = await performSearch(
+				browser,
+				data.body.query,
+				data.body.limit,
+			);
 
-		const promises = [];
-		for (const result of searchResults) {
-			promises.push(extractContent(browser, result));
+			const promises = [];
+			for (const result of searchResults) {
+				promises.push(extractContent(browser, result));
+			}
+
+			const results = await Promise.all(promises);
+
+			return {
+				success: true,
+				data: results.filter((obj) => obj !== null),
+			};
+		} finally {
+			await browser.close();
 		}
-
-		const results = await Promise.all(promises);
-
-		return {
-			success: true,
-			data: results.filter((obj) => obj !== null),
-		};
 	}
 }


### PR DESCRIPTION
## Summary

- The `Browser` instance launched in `WebSearch.handle()` was never closed after use, which could lead to resource exhaustion on Cloudflare Workers' Browser Rendering API
- Wrapped the search and content extraction logic in a `try/finally` block to ensure `browser.close()` is always called, even if an error occurs during search or content extraction
- Also applied auto-fix from biome formatter on a couple of pre-existing lint issues (missing semicolons)

## Why this matters

Each call to `puppeteer.launch()` opens a new browser session via Cloudflare's Browser Rendering binding. Without calling `browser.close()`, these sessions accumulate and are never properly cleaned up. This fix ensures proper resource lifecycle management.

## Test plan

- [ ] Deploy to a test worker and verify `/v1/search` still returns results correctly
- [ ] Confirm browser sessions are properly released after each request

🤖 Generated with [Claude Code](https://claude.com/claude-code)