### PR TITLE
Fix sourceUrl casing to match OpenAPI schema and Firecrawl API

### DIFF
--- a/src/webSearch.ts
+++ b/src/webSearch.ts
@@ -103,7 +103,7 @@ async function extractContent(browser: Browser, url: string) {
 			metadata: {
 				title: title,
 				description: description,
-				sourceUrl: url,
+				sourceURL: url,
 				statusCode: statusCode,
 				error: null,
 			},


### PR DESCRIPTION
## Summary

- Fixed `metadata.sourceUrl` → `metadata.sourceURL` in the `extractContent` response to match the OpenAPI response schema definition and the Firecrawl API convention

## Why this matters

The OpenAPI response schema at line 174 of `webSearch.ts` defines the field as `sourceURL`, but the actual response object at line 106 returned `sourceUrl` (lowercase 'rl'). This casing mismatch means Firecrawl SDK clients reading `metadata.sourceURL` from the response would get `undefined` instead of the actual source URL.

## Changes

- `src/webSearch.ts`: Changed `sourceUrl` to `sourceURL` in the `extractContent` function's return object (line 106)

## Test plan

- [ ] Verify `/v1/search` responses include `metadata.sourceURL` (not `metadata.sourceUrl`)
- [ ] Confirm Firecrawl SDK clients can read the `sourceURL` field correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)