### PR TITLE
Fix html field to return cleaned HTML instead of raw HTML

### DIFF
--- a/src/webSearch.ts
+++ b/src/webSearch.ts
@@ -96,7 +96,7 @@ async function extractContent(browser: Browser, url: string) {
 				/* customTranslators (optional) */ undefined,
 				/* customCodeBlockTranslators (optional) */ undefined,
 			),
-			html: rawHtml,
+			html: content,
 			rawHtml: rawHtml,
 			links: links,
 			screenshot: null,


### PR DESCRIPTION
## Summary

- Fixed the `html` field in `extractContent` to return cleaned HTML (`content`) instead of raw HTML (`rawHtml`)

## What changed

In `src/webSearch.ts`, the `extractContent` function already computes a cleaned version of the page HTML by cloning `document.body` and removing `script`, `style`, `nav`, `header`, and `footer` elements. This cleaned HTML is stored in the `content` variable and is correctly used for the `markdown` field conversion.

However, the `html` field was incorrectly returning `rawHtml` (the full unprocessed page HTML from `page.content()`), making it identical to the `rawHtml` field. Per the Firecrawl API convention:
- `html` → cleaned/processed HTML content
- `rawHtml` → raw, unprocessed page HTML

This one-line fix changes `html: rawHtml` to `html: content`, so both fields now return distinct, useful values.

## Why this matters

Firecrawl SDK consumers relying on the `html` field expect cleaned HTML without scripts, styles, and navigation elements. Returning the raw HTML defeats the purpose of having separate `html` and `rawHtml` fields.

## Test plan

- [ ] Verify `/v1/search` responses return cleaned HTML in the `html` field (no `<script>`, `<style>`, `<nav>`, `<header>`, `<footer>` tags)
- [ ] Verify `rawHtml` still contains the full unprocessed page HTML
- [ ] Verify `markdown` output is unchanged (it already used `content`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)