### PR TITLE
Add /v1/map endpoint for website URL discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ you’re ready to go!
 ## Features
 
 - **`/search` Endpoint**: Perform web searches and retrieve structured results, compatible with Firecrawl SDKs.
+- **`/map` Endpoint**: Discover all URLs on a website by extracting links from the page and optionally parsing its sitemap.xml.
 - **Cloudflare Browser Rendering**: Powers real-time web scraping and content extraction.
 - **Firecrawl SDK Compatibility**: Seamlessly integrates with existing Firecrawl-based applications.
 
@@ -95,6 +96,10 @@ const firecrawl = new FirecrawlApp({
 // Example search
 const results = await firecrawl.search('test query');
 console.log(results);
+
+// Example map — discover all URLs on a website
+const mapResult = await firecrawl.map('https://example.com');
+console.log(mapResult);
 ```
 
 ### Customization

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { fromHono } from "chanfana";
 import { type Context, Hono } from "hono";
 import { authorizationMiddleware } from "./authorization";
+import { WebMap } from "./webMap";
 import { WebSearch } from "./webSearch";
 
 export type Env = {
@@ -18,6 +19,7 @@ const openapi = fromHono(app, { docs_url: "/" });
 
 // Register OpenAPI endpoints (this will also register the routes in Hono)
 openapi.post("/v1/search", WebSearch);
+openapi.post("/v1/map", WebMap);
 
 // Export the Hono app
 export default app;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { fromHono } from "chanfana";
 import { type Context, Hono } from "hono";
 import { authorizationMiddleware } from "./authorization";
-import { WebMap } from "./webMap";
 import { WebScrape } from "./scrape";
+import { WebMap } from "./webMap";
 import { WebSearch } from "./webSearch";
 
 export type Env = {

--- a/src/webMap.ts
+++ b/src/webMap.ts
@@ -1,0 +1,175 @@
+import puppeteer, { type Browser } from "@cloudflare/puppeteer";
+import { OpenAPIRoute, contentJson } from "chanfana";
+import { z } from "zod";
+import type { AppContext, Env } from "./index";
+
+async function getBrowser(env: Env): Promise<Browser> {
+	return await puppeteer.launch(env.BROWSER);
+}
+
+async function discoverLinks(
+	browser: Browser,
+	url: string,
+	includeSubdomains: boolean,
+): Promise<string[]> {
+	const page = await browser.newPage();
+	try {
+		await page.goto(url, { waitUntil: "domcontentloaded" });
+
+		const targetHostname = new URL(url).hostname;
+
+		const links: string[] = await page.evaluate(
+			(targetHost: string, includeSubs: boolean) => {
+				const anchors = Array.from(document.querySelectorAll("a"));
+				const hrefs: string[] = [];
+				for (const a of anchors) {
+					const href = a.href;
+					if (!href || !href.startsWith("http")) continue;
+					try {
+						const linkHost = new URL(href).hostname;
+						const matches = includeSubs
+							? linkHost === targetHost || linkHost.endsWith(`.${targetHost}`)
+							: linkHost === targetHost;
+						if (matches) {
+							hrefs.push(href);
+						}
+					} catch {
+						// Skip invalid URLs
+					}
+				}
+				return hrefs;
+			},
+			targetHostname,
+			includeSubdomains,
+		);
+
+		// Normalize and deduplicate
+		const seen = new Set<string>();
+		const result: string[] = [];
+		for (const link of links) {
+			try {
+				const parsed = new URL(link);
+				parsed.hash = "";
+				// Remove trailing slash for consistency (except root path)
+				let normalized = parsed.toString();
+				if (normalized.endsWith("/") && parsed.pathname !== "/") {
+					normalized = normalized.slice(0, -1);
+				}
+				if (!seen.has(normalized)) {
+					seen.add(normalized);
+					result.push(normalized);
+				}
+			} catch {
+				// Skip invalid URLs
+			}
+		}
+
+		return result;
+	} catch (error) {
+		console.error(
+			`Link discovery failed for ${url}: ${(error as Error).message}`,
+		);
+		return [];
+	} finally {
+		await page.close();
+	}
+}
+
+async function parseSitemap(baseUrl: string): Promise<string[]> {
+	try {
+		const origin = new URL(baseUrl).origin;
+		const sitemapUrl = `${origin}/sitemap.xml`;
+		const response = await fetch(sitemapUrl);
+
+		if (!response.ok) {
+			return [];
+		}
+
+		const text = await response.text();
+		const urls: string[] = [];
+		const locRegex = /<loc>\s*(.*?)\s*<\/loc>/g;
+		let match: RegExpExecArray | null;
+		while ((match = locRegex.exec(text)) !== null) {
+			const loc = match[1].trim();
+			if (loc.startsWith("http")) {
+				urls.push(loc);
+			}
+		}
+
+		return urls;
+	} catch {
+		return [];
+	}
+}
+
+export class WebMap extends OpenAPIRoute {
+	schema = {
+		request: {
+			body: {
+				content: {
+					"application/json": {
+						schema: z.object({
+							url: z.string().url(),
+							search: z.string().optional(),
+							ignoreSitemap: z.boolean().default(false).optional(),
+							includeSubdomains: z.boolean().default(false).optional(),
+							limit: z.number().min(1).max(5000).default(5000).optional(),
+						}),
+					},
+				},
+			},
+		},
+		responses: {
+			200: {
+				description: "response",
+				...contentJson({
+					success: z.boolean(),
+					links: z.string().array(),
+				}),
+			},
+		},
+	};
+
+	async handle(c: AppContext) {
+		const data = await this.getValidatedData<typeof this.schema>();
+
+		const browser = await getBrowser(c.env);
+		try {
+			const pageLinks = await discoverLinks(
+				browser,
+				data.body.url,
+				data.body.includeSubdomains ?? false,
+			);
+
+			let sitemapLinks: string[] = [];
+			if (!data.body.ignoreSitemap) {
+				sitemapLinks = await parseSitemap(data.body.url);
+			}
+
+			// Merge and deduplicate
+			const allLinks = new Set<string>([...pageLinks, ...sitemapLinks]);
+			let links = Array.from(allLinks);
+
+			// Filter by search term if provided
+			if (data.body.search) {
+				const searchLower = data.body.search.toLowerCase();
+				links = links.filter((link) =>
+					link.toLowerCase().includes(searchLower),
+				);
+			}
+
+			// Sort alphabetically for deterministic output
+			links.sort();
+
+			// Apply limit
+			links = links.slice(0, data.body.limit);
+
+			return {
+				success: true,
+				links: links,
+			};
+		} finally {
+			await browser.close();
+		}
+	}
+}

--- a/tests/unit/map-validation.test.ts
+++ b/tests/unit/map-validation.test.ts
@@ -1,0 +1,195 @@
+import { Hono } from "hono";
+import { OpenAPIRoute, fromHono } from "chanfana";
+import { describe, expect, it } from "vitest";
+import type { Env } from "../../src/index";
+import { z } from "zod";
+
+// Stub endpoint using the same schema as the real WebMap endpoint
+// to test request validation without importing puppeteer
+class StubMapEndpoint extends OpenAPIRoute {
+	schema = {
+		request: {
+			body: {
+				content: {
+					"application/json": {
+						schema: z.object({
+							url: z.string().url(),
+							search: z.string().optional(),
+							ignoreSitemap: z.boolean().default(false).optional(),
+							includeSubdomains: z.boolean().default(false).optional(),
+							limit: z.number().min(1).max(5000).default(5000).optional(),
+						}),
+					},
+				},
+			},
+		},
+	};
+
+	async handle() {
+		const data = await this.getValidatedData<typeof this.schema>();
+		return {
+			success: true,
+			links: [],
+		};
+	}
+}
+
+function createApp() {
+	const app = new Hono<{ Bindings: Env }>();
+	const openapi = fromHono(app, { docs_url: "/" });
+	openapi.post("/v1/map", StubMapEndpoint);
+	return app;
+}
+
+describe("Map Endpoint Validation", () => {
+	const env = {};
+
+	it("accepts valid request with just url", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/map",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ url: "https://example.com" }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.success).toBe(true);
+	});
+
+	it("accepts valid request with url and limit", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/map",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ url: "https://example.com", limit: 100 }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.success).toBe(true);
+	});
+
+	it("accepts valid request with all optional fields", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/map",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					url: "https://example.com",
+					search: "blog",
+					ignoreSitemap: true,
+					includeSubdomains: true,
+					limit: 500,
+				}),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.success).toBe(true);
+	});
+
+	it("rejects request with empty JSON body", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/map",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({}),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.success).toBe(false);
+	});
+
+	it("rejects request without url field", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/map",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ search: "test" }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.success).toBe(false);
+	});
+
+	it("rejects invalid URL format", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/map",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ url: "not-a-url" }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.success).toBe(false);
+	});
+
+	it("rejects limit exceeding maximum (5000)", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/map",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ url: "https://example.com", limit: 10000 }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.success).toBe(false);
+	});
+
+	it("rejects limit below minimum (1)", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/map",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ url: "https://example.com", limit: 0 }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.success).toBe(false);
+	});
+
+	it("returns 404 for GET /v1/map (only POST allowed)", async () => {
+		const app = createApp();
+		const res = await app.request("/v1/map", { method: "GET" }, env);
+
+		expect(res.status).toBe(404);
+	});
+});


### PR DESCRIPTION
## Summary
- Adds a new `POST /v1/map` endpoint that discovers all URLs on a website by extracting internal links from the page DOM and optionally parsing the site's `sitemap.xml`
- Supports filtering discovered URLs by search keyword, subdomain inclusion, and result limiting
- Follows existing codebase patterns (OpenAPIRoute, Zod validation, Puppeteer browser sessions)

## Related Issue
Prodboard issue: f920b3cc79bf8b13 — [I] [workers-firecrawl] Implement /v1/map endpoint for website URL discovery

## Changes
- **`src/webMap.ts`** (new): `WebMap` OpenAPIRoute handler with `discoverLinks()` for DOM link extraction and `parseSitemap()` for sitemap.xml parsing via `fetch()`
- **`src/index.ts`**: Register `POST /v1/map` route
- **`tests/unit/map-validation.test.ts`** (new): 9 unit tests covering request validation (valid URLs, missing fields, invalid formats, limit bounds, routing)
- **`README.md`**: Added `/map` endpoint to Features section and usage example

## Request Schema
```json
{
  "url": "https://example.com",        // required
  "search": "blog",                     // optional: filter URLs containing this string
  "ignoreSitemap": false,               // optional: skip sitemap.xml parsing
  "includeSubdomains": false,           // optional: include subdomain links
  "limit": 5000                         // optional: max URLs to return (1-5000)
}
```

## Test Plan
- [x] All 25 tests pass (16 existing + 9 new)
- [x] Lint passes with biome
- [ ] Manual testing with `npx wrangler dev --remote` against real websites
- [ ] Verify Swagger UI shows the new endpoint with correct schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)