### PR TITLE
ci: add changeset check for pull requests

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,23 @@
+name: Changeset Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  changeset-check:
+    if: github.head_ref != 'changeset-release/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - run: npm ci
+
+      - name: Check for changesets
+        run: npx changeset status --since=origin/main


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that enforces every PR to include a changeset entry before merging.

The workflow runs `npx changeset status --since=origin/main` on every pull request to `main`, and skips the automated `changeset-release/main` branch.

## Why
The repo already uses changesets for versioning and publishing, but PRs could be merged without a changeset — meaning releases could miss changes. This ensures every PR is tracked.