### PR TITLE
Honor scrapeOptions.formats filtering and add screenshot capture

### DIFF
--- a/.changeset/scrape-formats-filtering.md
+++ b/.changeset/scrape-formats-filtering.md
@@ -1,0 +1,10 @@
+---
+"workers-firecrawl": minor
+---
+
+Honor scrapeOptions.formats filtering and add screenshot capture
+
+- Implement format filtering in /v1/search so only client-requested content formats are returned
+- Add screenshot and screenshot@fullPage capture using Puppeteer's page.screenshot()
+- Skip expensive processing (markdown conversion, raw HTML, link extraction) when not requested
+- Response objects now only include requested format fields, reducing payload size

--- a/README.md
+++ b/README.md
@@ -23,9 +23,41 @@ you’re ready to go!
 - **`/scrape` Endpoint**: Scrape a single URL and extract content in multiple formats (markdown, HTML, links, screenshot).
 - **Cloudflare Browser Rendering**: Powers real-time web scraping and content extraction.
 - **Firecrawl SDK Compatibility**: Seamlessly integrates with existing Firecrawl-based applications.
+- **Format Filtering**: Request only the content formats you need via `scrapeOptions.formats` to reduce payload size and improve performance.
+- **Screenshot Capture**: Capture viewport or full-page screenshots of search results as base64 data URIs.
 
 Additional endpoints or features can be requested
 via [GitHub Issues](https://github.com/G4brym/workers-firecrawl/issues).
+
+### Supported `scrapeOptions.formats`
+
+The `/v1/search` endpoint supports the `scrapeOptions.formats` parameter to control which content formats are returned per result. When omitted, the default formats are `["markdown", "html", "rawHtml", "links"]`.
+
+| Format | Description |
+|---|---|
+| `markdown` | Page content converted to Markdown |
+| `html` | Cleaned HTML content (scripts, styles, nav, header, footer removed) |
+| `rawHtml` | Full raw HTML of the page |
+| `links` | Array of all link URLs found on the page |
+| `screenshot` | Viewport screenshot as a `data:image/png;base64,...` data URI |
+| `screenshot@fullPage` | Full-page screenshot as a `data:image/png;base64,...` data URI |
+| `extract` | Accepted by the schema but not yet implemented (requires LLM integration) |
+
+**Example — request only markdown:**
+
+```javascript
+const results = await firecrawl.search('test query', {
+    scrapeOptions: { formats: ['markdown'] }
+});
+```
+
+**Example — request markdown with a screenshot:**
+
+```javascript
+const results = await firecrawl.search('test query', {
+    scrapeOptions: { formats: ['markdown', 'screenshot'] }
+});
+```
 
 ## Basic Usage
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_FORMATS = [
+	"markdown",
+	"html",
+	"rawHtml",
+	"links",
+] as const;

--- a/src/webSearch.ts
+++ b/src/webSearch.ts
@@ -2,6 +2,7 @@ import type { Browser } from "@cloudflare/puppeteer";
 import { OpenAPIRoute, contentJson } from "chanfana";
 import { z } from "zod";
 import { extractContent, getBrowser } from "./browser";
+import { DEFAULT_FORMATS } from "./constants";
 import type { AppContext } from "./index";
 
 async function performSearch(browser: Browser, query: string, limit: number) {
@@ -75,17 +76,17 @@ export class WebSearch extends OpenAPIRoute {
 							title: z.string(),
 							description: z.string(),
 							url: z.string(),
-							markdown: z.string(),
-							html: z.string(),
-							rawHtml: z.string(),
-							links: z.string().array(),
-							screenshot: z.string(),
+							markdown: z.string().optional(),
+							html: z.string().optional(),
+							rawHtml: z.string().optional(),
+							links: z.string().array().optional(),
+							screenshot: z.string().optional().nullable(),
 							metadata: z.object({
 								title: z.string(),
 								description: z.string(),
 								sourceURL: z.string(),
 								statusCode: z.number().int(),
-								error: z.string(),
+								error: z.string().nullable(),
 							}),
 						})
 						.array(),
@@ -97,6 +98,7 @@ export class WebSearch extends OpenAPIRoute {
 
 	async handle(c: AppContext) {
 		const data = await this.getValidatedData<typeof this.schema>();
+		const formats = data.body.scrapeOptions?.formats ?? [...DEFAULT_FORMATS];
 
 		const browser = await getBrowser(c.env);
 		try {
@@ -108,7 +110,7 @@ export class WebSearch extends OpenAPIRoute {
 
 			const promises = [];
 			for (const result of searchResults) {
-				promises.push(extractContent(browser, result));
+				promises.push(extractContent(browser, result, { formats }));
 			}
 
 			const results = await Promise.all(promises);

--- a/tests/unit/search-validation.test.ts
+++ b/tests/unit/search-validation.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 import type { Env } from "../../src/index";
 import { z } from "zod";
 
+const DEFAULT_FORMATS = ["markdown", "html", "rawHtml", "links"];
+
 // Stub endpoint using the same schema as the real WebSearch endpoint
 // to test request validation without importing puppeteer/node-html-markdown
 class StubSearchEndpoint extends OpenAPIRoute {
@@ -45,11 +47,15 @@ class StubSearchEndpoint extends OpenAPIRoute {
 
 	async handle() {
 		const data = await this.getValidatedData<typeof this.schema>();
+		const formats = data.body.scrapeOptions?.formats ?? [
+			...DEFAULT_FORMATS,
+		];
 		return {
 			success: true,
 			data: [],
 			query: data.body.query,
 			limit: data.body.limit,
+			formats: formats,
 		};
 	}
 }
@@ -169,5 +175,147 @@ describe("Search Endpoint Validation", () => {
 		expect(res.status).toBe(200);
 		const body = await res.json();
 		expect(body.success).toBe(true);
+	});
+});
+
+describe("Format Filtering Validation", () => {
+	const env = {};
+
+	it("accepts request with specific formats and echoes them back", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/search",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					query: "test",
+					scrapeOptions: { formats: ["markdown"] },
+				}),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.success).toBe(true);
+		expect(body.formats).toEqual(["markdown"]);
+	});
+
+	it("accepts request with screenshot format", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/search",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					query: "test",
+					scrapeOptions: { formats: ["screenshot"] },
+				}),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.formats).toEqual(["screenshot"]);
+	});
+
+	it("accepts request with screenshot@fullPage format", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/search",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					query: "test",
+					scrapeOptions: { formats: ["screenshot@fullPage"] },
+				}),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.formats).toEqual(["screenshot@fullPage"]);
+	});
+
+	it("accepts request with multiple formats", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/search",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					query: "test",
+					scrapeOptions: { formats: ["markdown", "html", "screenshot"] },
+				}),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.formats).toEqual(["markdown", "html", "screenshot"]);
+	});
+
+	it("rejects request with invalid format", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/search",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					query: "test",
+					scrapeOptions: { formats: ["invalid"] },
+				}),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.success).toBe(false);
+	});
+
+	it("returns default formats when scrapeOptions is omitted", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/search",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ query: "test" }),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.formats).toEqual(DEFAULT_FORMATS);
+	});
+
+	it("returns default formats when formats array is omitted from scrapeOptions", async () => {
+		const app = createApp();
+		const res = await app.request(
+			"/v1/search",
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					query: "test",
+					scrapeOptions: {},
+				}),
+			},
+			env,
+		);
+
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.formats).toEqual(DEFAULT_FORMATS);
 	});
 });

--- a/tests/unit/search-validation.test.ts
+++ b/tests/unit/search-validation.test.ts
@@ -2,9 +2,8 @@ import { Hono } from "hono";
 import { OpenAPIRoute, fromHono } from "chanfana";
 import { describe, expect, it } from "vitest";
 import type { Env } from "../../src/index";
+import { DEFAULT_FORMATS } from "../../src/constants";
 import { z } from "zod";
-
-const DEFAULT_FORMATS = ["markdown", "html", "rawHtml", "links"];
 
 // Stub endpoint using the same schema as the real WebSearch endpoint
 // to test request validation without importing puppeteer/node-html-markdown


### PR DESCRIPTION
## Summary
- Implement actual `scrapeOptions.formats` filtering in the `/v1/search` endpoint so only client-requested content formats are returned
- Add screenshot capture support using Puppeteer's `page.screenshot()` with base64 data URI encoding
- Skip expensive processing (markdown conversion, raw HTML extraction, link extraction) when those formats aren't requested, improving performance

## Changes
- **`src/webSearch.ts`**:
  - Add `DEFAULT_FORMATS` constant (`["markdown", "html", "rawHtml", "links"]`) for backwards-compatible defaults when no formats specified
  - Update `extractContent()` to accept a `formats` parameter
  - Conditionally execute link extraction, raw HTML fetching, and markdown conversion based on requested formats
  - Capture screenshots as `data:image/png;base64,...` strings when `screenshot` or `screenshot@fullPage` is requested
  - Build response objects with only the requested format fields (always includes `url`, `title`, `description`, `metadata`)
  - Update response Zod schema to make format-dependent fields optional/nullable
  - Pass parsed formats from `handle()` through to `extractContent()`

- **`tests/unit/search-validation.test.ts`**:
  - Update stub endpoint to echo back parsed formats for testing
  - Add 7 new test cases for format filtering validation:
    - Specific format request echoed back correctly
    - Screenshot format accepted
    - screenshot@fullPage format accepted
    - Multiple formats accepted
    - Invalid format rejected with 400
    - Default formats returned when scrapeOptions omitted
    - Default formats returned when formats array omitted from scrapeOptions

## Backwards Compatibility
When no `scrapeOptions.formats` is specified, behavior is identical to the previous implementation — all text formats (`markdown`, `html`, `rawHtml`, `links`) are returned. Screenshots remain opt-in only.

## Test Plan
- [x] All 23 unit tests pass (6 existing + 7 new format tests + 10 other)
- [x] Lint passes clean (`biome check`)
- [ ] Manual testing with deployed Worker (requires Browser Rendering binding)
- [ ] Verify `formats: ["markdown"]` returns only markdown + metadata
- [ ] Verify `formats: ["screenshot"]` returns base64 screenshot data URI
- [ ] Verify request without `scrapeOptions` returns all text formats (backwards compat)

## Notes
- The `extract` format is accepted by the schema but silently skipped (requires LLM integration, tracked separately)
- Full-page screenshots of very long pages may produce large base64 strings; consider adding a max viewport height cap in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)